### PR TITLE
Fix shell injection risk in command execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Execution rules:
 - high risk commands always require an explicit confirmation phrase
 - `--yes` never bypasses the high-risk confirmation path
 - unsupported host OSes can still generate best-effort Unix-style commands, but execution is disabled
+- commands that require shell control syntax such as pipes, command chaining, redirects, or substitutions are blocked from direct execution and should be copied for manual review instead
 
 Example high-risk confirmation:
 

--- a/src/exec/runCommand.ts
+++ b/src/exec/runCommand.ts
@@ -1,4 +1,4 @@
-import { execa, execaCommand } from "execa";
+import { execa } from "execa";
 import { parse as parseShellCommand } from "shell-quote";
 
 import { ExecutionError } from "../utils/errors.js";
@@ -9,11 +9,27 @@ export interface RunCommandOptions {
   stdio?: "inherit" | "pipe";
 }
 
-const SHELL_REQUIRED_PATTERN =
-  /[|&;<>()$`*?[\]{}]|\b(?:if|then|fi|for|do|done|while|case)\b|^\s*[A-Za-z_][A-Za-z0-9_]*=/;
+const SHELL_SYNTAX_ERROR_MESSAGE =
+  "Shell control syntax is not supported for direct execution. Copy and run the command manually after reviewing it.";
+
+function parseCommandTokens(command: string): string[] {
+  const parsed = parseShellCommand(command);
+
+  if (parsed.some((part) => typeof part !== "string")) {
+    throw new ExecutionError(SHELL_SYNTAX_ERROR_MESSAGE);
+  }
+
+  return parsed
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+}
 
 export function needsShellExecution(command: string): boolean {
-  return SHELL_REQUIRED_PATTERN.test(command);
+  try {
+    return parseShellCommand(command).some((part) => typeof part !== "string");
+  } catch {
+    return true;
+  }
 }
 
 export async function runCommand(
@@ -21,35 +37,7 @@ export async function runCommand(
   options: RunCommandOptions = {}
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
   try {
-    if (needsShellExecution(command)) {
-      const executionOptions = {
-        ...(options.cwd ? { cwd: options.cwd } : {}),
-        ...(options.env ? { env: options.env } : {}),
-        stdio: options.stdio ?? "inherit",
-        reject: false as const,
-        shell: true as const
-      };
-      const result = await execaCommand(command, {
-        ...executionOptions
-      });
-
-      if (result.exitCode !== 0) {
-        throw new ExecutionError(
-          `Command failed with exit code ${result.exitCode}.`,
-          result.stderr || result.stdout
-        );
-      }
-
-      return {
-        exitCode: result.exitCode ?? 0,
-        stdout: result.stdout ?? "",
-        stderr: result.stderr ?? ""
-      };
-    }
-
-    const tokens = parseShellCommand(command).filter(
-      (part): part is string => typeof part === "string"
-    );
+    const tokens = parseCommandTokens(command);
     const [file, ...args] = tokens;
 
     if (!file) {

--- a/src/exec/runCommand.ts
+++ b/src/exec/runCommand.ts
@@ -1,7 +1,7 @@
 import { execa } from "execa";
 import { parse as parseShellCommand } from "shell-quote";
 
-import { ExecutionError } from "../utils/errors.js";
+import { ExecutionError, ExecutionPolicyError } from "../utils/errors.js";
 
 export interface RunCommandOptions {
   cwd?: string;
@@ -16,7 +16,7 @@ function parseCommandTokens(command: string): string[] {
   const parsed = parseShellCommand(command);
 
   if (parsed.some((part) => typeof part !== "string")) {
-    throw new ExecutionError(SHELL_SYNTAX_ERROR_MESSAGE);
+    throw new ExecutionPolicyError(SHELL_SYNTAX_ERROR_MESSAGE);
   }
 
   return parsed
@@ -64,7 +64,7 @@ export async function runCommand(
       stderr: result.stderr ?? ""
     };
   } catch (error) {
-    if (error instanceof ExecutionError) {
+    if (error instanceof ExecutionError || error instanceof ExecutionPolicyError) {
       throw error;
     }
 

--- a/tests/unit/runCommand.test.ts
+++ b/tests/unit/runCommand.test.ts
@@ -23,7 +23,7 @@ describe("runCommand", () => {
     await expect(
       runCommand("echo safe; echo injected", { stdio: "pipe" })
     ).rejects.toMatchObject({
-      code: "EXECUTION_ERROR",
+      code: "EXECUTION_POLICY_ERROR",
       message:
         "Shell control syntax is not supported for direct execution. Copy and run the command manually after reviewing it."
     });

--- a/tests/unit/runCommand.test.ts
+++ b/tests/unit/runCommand.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { runCommand, needsShellExecution } from "../../src/exec/runCommand.js";
+import { ExecutionError } from "../../src/utils/errors.js";
+
+describe("runCommand", () => {
+  it("executes simple commands without a shell", async () => {
+    const result = await runCommand(
+      `${process.execPath} -e "process.stdout.write('ok')"`,
+      { stdio: "pipe" }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("ok");
+  });
+
+  it("detects shell control operators as shell-only syntax", () => {
+    expect(needsShellExecution("echo safe; echo injected")).toBe(true);
+    expect(needsShellExecution("echo safe | cat")).toBe(true);
+    expect(needsShellExecution("echo safe && echo injected")).toBe(true);
+  });
+
+  it("blocks shell control operators instead of running them with shell=true", async () => {
+    await expect(
+      runCommand("echo safe; echo injected", { stdio: "pipe" })
+    ).rejects.toMatchObject({
+      code: "EXECUTION_ERROR",
+      message:
+        "Shell control syntax is not supported for direct execution. Copy and run the command manually after reviewing it."
+    } satisfies Partial<ExecutionError>);
+  });
+});

--- a/tests/unit/runCommand.test.ts
+++ b/tests/unit/runCommand.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { runCommand, needsShellExecution } from "../../src/exec/runCommand.js";
-import { ExecutionError } from "../../src/utils/errors.js";
+import { needsShellExecution, runCommand } from "../../src/exec/runCommand.js";
 
 describe("runCommand", () => {
   it("executes simple commands without a shell", async () => {
@@ -27,6 +26,6 @@ describe("runCommand", () => {
       code: "EXECUTION_ERROR",
       message:
         "Shell control syntax is not supported for direct execution. Copy and run the command manually after reviewing it."
-    } satisfies Partial<ExecutionError>);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes #2.

This PR removes the unsafe `shell:true` execution path from `runCommand` and blocks shell control syntax before anything is executed.

## Changes

- Removes `execaCommand(..., { shell: true })` usage for AI-generated commands
- Parses commands with `shell-quote` and rejects non-string shell AST parts before execution
- Throws `ExecutionPolicyError` for blocked shell-only syntax
- Keeps direct execution for simple commands through `execa(file, args)` only
- Adds regression coverage for semicolon, pipe, and `&&` shell control operators
- Documents that shell-control commands must be copied and reviewed manually instead of executed directly

## Validation

- Diff reviewed through GitHub compare
- Automated tests were added for the fixed behavior
- I could not run npm validation locally from this ChatGPT container because it has no outbound DNS access to clone/install the repo

## Security note

The original issue was that risk classification existed but did not prevent direct shell execution. This PR changes the execution boundary itself: commands that need a shell are no longer executed automatically.